### PR TITLE
Revert 1517d5f healthcheck start period changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,4 +86,4 @@ RUN set -x && \
 EXPOSE 80/tcp
 
 # Add healthcheck
-HEALTHCHECK --start-period=3600s --interval=600s CMD /healthcheck.sh
+HEALTHCHECK --start-period=300s --interval=300s CMD /healthcheck.sh


### PR DESCRIPTION
In 1517d5f478f1dbbb568d39e6760e3b28b708fc41 (2 years ago) @mikenye set the healthcheck start period to 1 hour, up from 5 minutes. The commit has no further comment and I'm not sure why the start period was set for so long (is it to ensure that on first start planes eventually show up in remote places?) but it makes connecting the container to docker integrated reverse proxies like Traefik problematic, as they want to wait for the container to finish starting before adding the service. 

It's a long, long wait after every restart.

Reverting this- if there was a good reason for an hour wait maybe there's a number in between that's less extreme?