### PR TITLE
Add ability to have multiple heywhatsthat outlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ This container accepts HTTP connections on TCP port `80` by default. You can cha
 | `MLATPORT` | Optional. TCP port number of an MLAT provider (`mlat-client`) | 30105 |
 | `TZ` | Optional. Your local timezone in [TZ-database-name](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) format | |
 | `HEYWHATSTHAT_PANORAMA_ID` | Optional. Your `heywhatsthat.com` panorama ID. See <https://github.com/wiedehopf/tar1090#heywhatsthatcom-range-outline>. | |
+| `HEYWHATSTHAT_ALTS` | Optional. Comma separated altitudes in m for multiple outlines. | 12192 |
 | `HTTP_ACCESS_LOG` | Optional. Set to `true` to display HTTP server access logs. | `false` |
 | `HTTP_ERROR_LOG` | Optional. Set to `false` to hide HTTP server error logs. | `true` |
 | `READSB_MAX_RANGE` | Optional. Maximum range (in nautical miles). | `300` |

--- a/rootfs/etc/cont-init.d/06-range-outline
+++ b/rootfs/etc/cont-init.d/06-range-outline
@@ -6,7 +6,7 @@ if [ -n "${HEYWHATSTHAT_PANORAMA_ID}" ]; then
     curl \
         --silent \
         --output /usr/local/share/tar1090/html/upintheair.json \
-        "http://www.heywhatsthat.com/api/upintheair.json?id=${HEYWHATSTHAT_PANORAMA_ID}&refraction=0.25&alts=12192" || \
+        "http://www.heywhatsthat.com/api/upintheair.json?id=${HEYWHATSTHAT_PANORAMA_ID}&refraction=0.25&alts=${HEYWHATSTHAT_ALTS:-12192}" || \
         echo "WARNING: Unable to download panorama. Outline will not be available."; exit 0
 fi
 


### PR DESCRIPTION
Without change to the configuration, the same outline at 40'000ft is drawn, with something like `HEYWHATSTHAT_ALTS=305,3048,9144,12192` you get outlines at 1k, 10k,30k, and 40k.

This still draws all the outlines in the same color / same style. I'd like to also add the ability to modify that. One thing at a time, though.

This was tested locally and appears to work fine.

