### PR TITLE
telegraf: Trim .aircraft[].flight

### DIFF
--- a/rootfs/etc/telegraf/telegraf.d/readsb_aircraft_json.conf
+++ b/rootfs/etc/telegraf/telegraf.d/readsb_aircraft_json.conf
@@ -9,3 +9,6 @@
         path = "aircraft"
         tags = ["hex", "type", "flight", "category", "version", "squawk", "sil_type", "emergency", "ground", "host", "alert"]
         excluded_keys = ["mlat", "tisb"]
+[[processors.strings]]
+  [[processors.strings.trim]]
+    tag = "flight"


### PR DESCRIPTION
trims extra whitespace, turns:
```
readsb_aircraft_true_heading{alert="0",category="A3",emergency="",flight="TRA5H   ",hex="484f6d",host="tar1090",nav_modes="",r="PH-HSG",sil_type="perhour",squawk="1000",t="B738",type="adsb_icao",version="2"} 280.4
```
into
```
readsb_aircraft_true_heading{alert="0",category="A5",emergency="",flight="CSN345",hex="780db1",host="tar1090",nav_modes="",r="B-5970",sil_type="perhour",squawk="1000",t="A333",type="adsb_icao",version="2"} 232.22
```