### PR TITLE
InfuxDBV1.8 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -705,7 +705,6 @@ In order for Telegraf to output metrics to an [InfluxDBv2](https://docs.influxda
 | `INFLUXDBV2_ORG` | InfluxDB Organization to write into |
 | `INFLUXDBV2_BUCKET` | Destination bucket to write into |
 
-
 ### Output to InfluxDBv1.8
 
 In order for Telegraf to output metrics to a legacy[InfluxDBv1](https://docs.influxdata.com/influxdb/v1.8/) time-series database, the following environment variables can be used:

--- a/README.md
+++ b/README.md
@@ -705,6 +705,18 @@ In order for Telegraf to output metrics to an [InfluxDBv2](https://docs.influxda
 | `INFLUXDBV2_ORG` | InfluxDB Organization to write into |
 | `INFLUXDBV2_BUCKET` | Destination bucket to write into |
 
+
+### Output to InfluxDBv1.8
+
+In order for Telegraf to output metrics to a legacy[InfluxDBv1](https://docs.influxdata.com/influxdb/v1.8/) time-series database, the following environment variables can be used:
+
+| Variable | Description |
+| ---- | ---- |
+| `INFLUXDB_URL` | The URL of the InfluxDB instance |
+| `INFLUXDB_DATABASE` | database in InfluxDB to store data in |
+| `INFLUXDB_USERNAME` | username to authenticate to InfluxDB as |
+| `INFLUXDB_PASSWORD` | password for InfluxDB User |
+
 ### Output to Prometheus
 
 In order for Telegraf to serve a [Prometheus](https://prometheus.io) endpoint, the following environment variables can be used:

--- a/rootfs/etc/cont-init.d/10-telegraf-conf
+++ b/rootfs/etc/cont-init.d/10-telegraf-conf
@@ -23,6 +23,18 @@ if [[ -n "$INFLUXDBV2_URL" ]]; then
     } >> "$TELEGRAF_OUTPUT_FILE"
 fi
 
+# configure InfluxDB if a URL is given
+if [[ -n "$INFLUXDB_URL" ]]; then
+    {
+        echo "[[outputs.influxdb]]"
+        echo "  urls = [\"$INFLUXDB_URL\"]"
+        echo "  database = \"$INFLUXDB_DATABASE\""
+        echo "  username = \"$INFLUXDB_USERNAME\""
+        echo "  password = \"$INFLUXDB_PASSWORD\""
+        echo ""
+    } >> "$TELEGRAF_OUTPUT_FILE"
+fi
+
 # configure Prometheus if required
 if [[ ${PROMETHEUS_ENABLE^^} == "TRUE" ]]; then
     {


### PR DESCRIPTION
There is no option for InfuxDB2 to run in a container on a Raspberry PI, but InfluxDB1.8 is supported, this enables the output for InfluxDBV1 in Telegraf. 