### PR TITLE
Telegraf alt_baro datatype conversion

### DIFF
--- a/rootfs/etc/telegraf/telegraf.d/readsb_aircraft_json.conf
+++ b/rootfs/etc/telegraf/telegraf.d/readsb_aircraft_json.conf
@@ -12,3 +12,6 @@
 [[processors.strings]]
   [[processors.strings.trim]]
     tag = "flight"
+[[processors.converter]]
+  [processors.converter.fields]
+    float = ["alt_baro"]


### PR DESCRIPTION
The alt_baro readsb metric produces either a numeric value or the string "ground".

Prometheus doesn't support strings as metrics and will ignore strings. Therefore, there is no problem with Prometheus having a forced data type.

In the case of InfluxDB 2, the first value of the key submitted will define the data type of that field. When "ground" is the first value, Influx will only populate the field when the value is "ground" and fire an error that Influx couldn't convert float to string. This will cause no altitude metrics to be collected.

To keep InfluxDB metrics in line with Prometheus, the data type must be forced as a float.

This does not affect Prometheus since it's dumping strings anyway, and it brings Influx data on par with the Prometheus data.

Further work needs to be done to collect the "ground" value to retain the data, but this will fix the issue of starting a new bucket and not gathering altitude metrics.