### PR TITLE
fix biastee

### DIFF
--- a/rootfs/etc/s6-overlay/s6-rc.d/09-rtlsdr-biastee/down
+++ b/rootfs/etc/s6-overlay/s6-rc.d/09-rtlsdr-biastee/down
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /etc/s6-overlay/scripts/09-rtlsdr-biastee-down

--- a/rootfs/etc/s6-overlay/s6-rc.d/09-rtlsdr-biastee/type
+++ b/rootfs/etc/s6-overlay/s6-rc.d/09-rtlsdr-biastee/type
@@ -1,0 +1,1 @@
+oneshot

--- a/rootfs/etc/s6-overlay/s6-rc.d/09-rtlsdr-biastee/up
+++ b/rootfs/etc/s6-overlay/s6-rc.d/09-rtlsdr-biastee/up
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /etc/s6-overlay/scripts/09-rtlsdr-biastee-init


### PR DESCRIPTION
During the startup stuff simplification this script was missed as it's not present in the git but pulled in from the Dockerfile

Got the oneshot service files for the biastee stuff back and made readsb depend on it for guaranteed ordering.