### PR TITLE
remove S6 settings which are no longer necessary / startup service improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,7 @@
 
 FROM ghcr.io/sdr-enthusiasts/docker-baseimage:wreadsb
 
-ENV S6_BEHAVIOUR_IF_STAGE2_FAILS=2 \
-    S6_SERVICES_GRACETIME=20000 \
-    S6_KILL_GRACETIME=20000 \
-    BEASTPORT=30005 \
+ENV BEASTPORT=30005 \
     GITPATH_TIMELAPSE1090=/opt/timelapse1090 \
     HTTP_ACCESS_LOG="false" \
     HTTP_ERROR_LOG="true" \

--- a/rootfs/etc/s6-overlay/s6-rc.d/startup/down
+++ b/rootfs/etc/s6-overlay/s6-rc.d/startup/down
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /etc/s6-overlay/scripts/startup-finish

--- a/rootfs/etc/s6-overlay/scripts/startup
+++ b/rootfs/etc/s6-overlay/scripts/startup
@@ -10,9 +10,11 @@ if ! [[ -d "$SDIR" ]] || [[ -z "$(ls "$SDIR")" ]]; then
     exit 0
 fi
 
-for NAME in "$SDIR"/*; do
-    if ! s6wrap --quiet --prepend="$NAME" --timestamps --args "$NAME"; then
-        s6wrap --quiet --prepend=startup --timestamps --args echo Error running "$NAME"
+cd "$SDIR" || exit 1
+
+for NAME in *; do
+    if ! s6wrap --quiet --prepend="$NAME" --timestamps --args "$SDIR/$NAME"; then
+        s6wrap --quiet --prepend=startup --timestamps --args echo Error running "$SDIR/$NAME"
         exit 1
     fi
 done

--- a/rootfs/etc/s6-overlay/scripts/startup-finish
+++ b/rootfs/etc/s6-overlay/scripts/startup-finish
@@ -1,0 +1,20 @@
+#!/command/with-contenv bash
+# shellcheck shell=bash disable=SC1091,SC2076
+
+source /scripts/common
+
+SDIR=/etc/s6-overlay/finish.d
+
+# exit 0 for nonexistent or empty directory
+if ! [[ -d "$SDIR" ]] || [[ -z "$(ls "$SDIR")" ]]; then
+    exit 0
+fi
+
+cd "$SDIR" || exit 1
+
+for NAME in *; do
+    if ! s6wrap --quiet --prepend="$NAME" --timestamps --args "$SDIR/$NAME"; then
+        s6wrap --quiet --prepend=startup --timestamps --args echo Error running "$SDIR/$NAME"
+        exit 1
+    fi
+done

--- a/rootfs/etc/s6-overlay/startup.d/01-sanity-check
+++ b/rootfs/etc/s6-overlay/startup.d/01-sanity-check
@@ -25,7 +25,7 @@ fi
 
 # Set up timezone
 if [ -z "${TZ}" ]; then
-  echo "${YELLOW}WARNING: TZ environment variable not set${NOCOLOR}"
+  echo -e "${YELLOW}WARNING: TZ environment variable not set${NOCOLOR}"
 else
   ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime && echo "$TZ" >/etc/timezone
 fi


### PR DESCRIPTION
Some S6 settings for this container are changed from the default, this is no longer necessary, so remove them. This means the container will exit on its own instead of running into the usual 10 second timeout of docker stop / compose down / compose up.

Simple fix for the timezone environment variable warning. (color code printed instead of colored warning)

startup service:
- don't print the whole path via s6wrap
- start after legacy services (not necessary for this container, but useful if this is ever moved to the baseimage)
- run scripts in /etc/s6-overlay/finish.d as down action (not necessary for this container but useful for reuse)