### PR TITLE
allow persistent directory for tar1090-update

### DIFF
--- a/rootfs/etc/s6-overlay/scripts/readsb
+++ b/rootfs/etc/s6-overlay/scripts/readsb
@@ -235,8 +235,11 @@ if [[ -n "$READSB_NET_VRS_PORT" ]]; then
 fi
 
 # make sure the db file exists, and if it does, use it
-if [[ -e $TAR1090_INSTALL_DIR/aircraft.csv.gz ]]; then
-    if [[ "$TAR1090_ENABLE_AC_DB" == "true" ]]; then
+if [[ "$TAR1090_ENABLE_AC_DB" == "true" ]]; then
+    if [[ -e $TAR1090_UPDATE_DIR/aircraft.csv.gz ]]; then
+        READSB_CMD+=("--db-file=$TAR1090_UPDATE_DIR/aircraft.csv.gz")
+    elif [[ -e $TAR1090_INSTALL_DIR/aircraft.csv.gz ]]; then
+        # fallback to container supplied not updated csv.gz
         READSB_CMD+=("--db-file=$TAR1090_INSTALL_DIR/aircraft.csv.gz")
     fi
 fi

--- a/rootfs/etc/s6-overlay/startup.d/02-tar1090-update
+++ b/rootfs/etc/s6-overlay/startup.d/02-tar1090-update
@@ -20,17 +20,17 @@ fi
 # aircraft-db
 if [[ "$TAR1090_ENABLE_AC_DB" == "true" ]]; then
     git ls-remote https://github.com/wiedehopf/tar1090-db | grep refs/heads/csv > "/run/aircraft.csv.gz.version.new"
-    if ! diff -q "${TAR1090_INSTALL_DIR}/aircraft.csv.gz.version" "/run/aircraft.csv.gz.version.new" &>/dev/null; then
+    if ! diff -q "${TAR1090_UPDATE_DIR}/aircraft.csv.gz.version" "/run/aircraft.csv.gz.version.new" &>/dev/null; then
         echo "Downloading https://raw.githubusercontent.com/wiedehopf/tar1090-db/csv/aircraft.csv.gz"
-        if curl --silent --show-error -o "${TAR1090_INSTALL_DIR}/aircraft.csv.gz.tmp" "https://raw.githubusercontent.com/wiedehopf/tar1090-db/csv/aircraft.csv.gz"; then
-            mv -f "${TAR1090_INSTALL_DIR}/aircraft.csv.gz.tmp" "${TAR1090_INSTALL_DIR}/aircraft.csv.gz"
-            mv -f "/run/aircraft.csv.gz.version.new" "${TAR1090_INSTALL_DIR}/aircraft.csv.gz.version"
+        if curl --silent --show-error -o "${TAR1090_UPDATE_DIR}/aircraft.csv.gz.tmp" "https://raw.githubusercontent.com/wiedehopf/tar1090-db/csv/aircraft.csv.gz"; then
+            mv -f "${TAR1090_UPDATE_DIR}/aircraft.csv.gz.tmp" "${TAR1090_UPDATE_DIR}/aircraft.csv.gz"
+            mv -f "/run/aircraft.csv.gz.version.new" "${TAR1090_UPDATE_DIR}/aircraft.csv.gz.version"
         fi
     fi
 fi
 
 # Print tar1090 version
-pushd "${TAR1090_INSTALL_DIR}/git" >/dev/null || exit 1
+pushd "${TAR1090_UPDATE_DIR}/git" >/dev/null || exit 1
 if [[ -z "$TAR1090_VERSION" ]]; then
     TAR1090_VERSION=$(git rev-parse --short HEAD)
 fi

--- a/rootfs/tar1090-install.sh
+++ b/rootfs/tar1090-install.sh
@@ -24,7 +24,11 @@ lighttpd=no
 nginx=no
 function useSystemd () { command -v systemd &>/dev/null; }
 
+gpath="$TAR1090_UPDATE_DIR"
+if [[ -z "$gpath" ]]; then gpath="$ipath"; fi
+
 mkdir -p "$ipath"
+mkdir -p "$gpath"
 
 if useSystemd && ! id -u tar1090 &>/dev/null
 then
@@ -85,8 +89,8 @@ fi
 
 dir=$(pwd)
 
-if (( $( { du -s "$ipath/git-db" 2>/dev/null || echo 0; } | cut -f1) > 150000 )); then
-    rm -rf "$ipath/git-db"
+if (( $( { du -s "$gpath/git-db" 2>/dev/null || echo 0; } | cut -f1) > 150000 )); then
+    rm -rf "$gpath/git-db"
 fi
 
 function getGIT() {
@@ -106,11 +110,11 @@ function revision() {
     git rev-parse --short HEAD 2>/dev/null || echo "$RANDOM-$RANDOM"
 }
 
-if ! { [[ "$1" == "test" ]] && cd "$ipath/git-db"; }; then
-    getGIT "$db_repo" "master" "$ipath/git-db" || true
+if ! { [[ "$1" == "test" ]] && cd "$gpath/git-db"; }; then
+    getGIT "$db_repo" "master" "$gpath/git-db" || true
 fi
 
-if ! cd "$ipath/git-db"
+if ! cd "$gpath/git-db"
 then
     echo "Unable to download files, exiting! (Maybe try again?)"
     exit 1
@@ -121,17 +125,17 @@ DB_VERSION=$(revision)
 cd "$dir"
 
 if [[ "$1" == "test" ]] || [[ -n "$git_source" ]]; then
-    mkdir -p "$ipath/git"
-    rm -rf "$ipath/git"/* || true
+    mkdir -p "$gpath/git"
+    rm -rf "$gpath/git"/* || true
     if [[ -n "$git_source" ]]; then
-        cp -r "$git_source"/* "$ipath/git"
+        cp -r "$git_source"/* "$gpath/git"
     else
-        cp -r ./* "$ipath/git"
+        cp -r ./* "$gpath/git"
     fi
-    cd "$ipath/git"
+    cd "$gpath/git"
     TAR_VERSION="$(date +%s)_${RANDOM}${RANDOM}"
 else
-    if ! getGIT "$repo" "master" "$ipath/git" || ! cd "$ipath/git"
+    if ! getGIT "$repo" "master" "$gpath/git" || ! cd "$gpath/git"
     then
         echo "Unable to download files, exiting! (Maybe try again?)"
         exit 1
@@ -274,7 +278,7 @@ do
     sed -i.orig -e "s?SOURCE_DIR?$srcdir?g" -e "s?SERVICE?${service}?g" tar1090.service
 
     cp -r -T html "$TMP"
-    cp -r -T "$ipath/git-db/db" "$TMP/db-$DB_VERSION"
+    cp -r -T "$gpath/git-db/db" "$TMP/db-$DB_VERSION"
     sed -i -e "s/let databaseFolder = .*;/let databaseFolder = \"db-$DB_VERSION\";/" "$TMP/index.html"
     echo "{ \"tar1090Version\": \"$TAR_VERSION\", \"databaseVersion\": \"$DB_VERSION\" }" > "$TMP/version.json"
 
@@ -306,7 +310,7 @@ do
 
     sed -i -e "s/tar1090 on github/tar1090 on github ($(date +%y%m%d))/" index.html
 
-    "$ipath/git/cachebust.sh" "$ipath/git/cachebust.list" "$TMP"
+    "$gpath/git/cachebust.sh" "$gpath/git/cachebust.list" "$TMP"
 
     rm -rf "$html_path"
     mv "$TMP" "$html_path"


### PR DESCRIPTION
when recreating the container via docker compose, changes in the docker image are lost. this means tar1090-update needs to download data again. especially when changes to container are made via automation, this can happen relatively often and it's desirable that the data are not required to be downloaded more than once

change the directory for the tar1090 and tar1090-db git dirs and the aircraft.csv.gz file to TAR1090_UPDATE_DIR=/var/globe_history/tar1090-update

this directory is already mounted on most installs and redownloads are avoided

the Dockerfile places aircraft.csv.gz in TAR1090_INSTALL_DIR so it can be used in the unlikely event of /var/globe_history being mounted while UPDATE_TAR1090 is false