### PR TITLE
speed up tar1090-update if files are up to date

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,6 +87,8 @@ RUN set -x && \
     git clone --single-branch --depth 1 "https://github.com/wiedehopf/timelapse1090.git" "${GITPATH_TIMELAPSE1090}" && \
     pushd "${GITPATH_TIMELAPSE1090}" && \
     bash -ec 'echo "timelapse1090 $(git log | head -1 | tr -s " " "_")" >> /VERSIONS' && \
+    # remove unused .git dir to slightly reduce image size
+    rm -rf "${GITPATH_TIMELAPSE1090}/.git" && \
     popd && \
     mkdir -p /var/timelapse1090 && \
     # aircraft-db, file in TAR1090_UPDATE_DIR will be preferred when starting readsb if tar1090-update enabled
@@ -167,6 +169,7 @@ RUN set -x && \
     # Clean-up.
     apt-get remove -y ${TEMP_PACKAGES[@]} && \
     apt-get autoremove -y && \
+    apt-get clean -q -y && \
     rm -rf /src/* /tmp/* /var/lib/apt/lists/* && \
     # document versions
     bash -ec 'grep -v tar1090-db /VERSIONS | grep tar1090 | cut -d " " -f 2 > /CONTAINER_VERSION' && \

--- a/rootfs/etc/s6-overlay/startup.d/02-tar1090-update
+++ b/rootfs/etc/s6-overlay/startup.d/02-tar1090-update
@@ -19,7 +19,7 @@ fi
 
 # aircraft-db
 if [[ "$TAR1090_ENABLE_AC_DB" == "true" ]]; then
-    git ls-remote https://github.com/wiedehopf/tar1090-db | grep refs/heads/csv > "/run/aircraft.csv.gz.version.new"
+    curl --silent --show-error "https://raw.githubusercontent.com/wiedehopf/tar1090-db/csv/version" > "/run/aircraft.csv.gz.version.new"
     if ! diff -q "${TAR1090_UPDATE_DIR}/aircraft.csv.gz.version" "/run/aircraft.csv.gz.version.new" &>/dev/null; then
         echo "Downloading https://raw.githubusercontent.com/wiedehopf/tar1090-db/csv/aircraft.csv.gz"
         if curl --silent --show-error -o "${TAR1090_UPDATE_DIR}/aircraft.csv.gz.tmp" "https://raw.githubusercontent.com/wiedehopf/tar1090-db/csv/aircraft.csv.gz"; then

--- a/rootfs/tar1090-install.sh
+++ b/rootfs/tar1090-install.sh
@@ -112,7 +112,7 @@ function revision() {
 
 if ! { [[ "$1" == "test" ]] && cd "$gpath/git-db"; }; then
     DB_VERSION_NEW=$(curl --silent --show-error "https://raw.githubusercontent.com/wiedehopf/tar1090-db/master/version")
-    if  [[ "$(cat $gpath/git-db/version 2>/dev/null)" != "$DB_VERSION_NEW" ]]; then
+    if  [[ "$(cat "$gpath/git-db/version" 2>/dev/null)" != "$DB_VERSION_NEW" ]]; then
         getGIT "$db_repo" "master" "$gpath/git-db" || true
     fi
 fi
@@ -139,7 +139,7 @@ if [[ "$1" == "test" ]] || [[ -n "$git_source" ]]; then
     TAR_VERSION="$(date +%s)_${RANDOM}${RANDOM}"
 else
     VERSION_NEW=$(curl --silent --show-error "https://raw.githubusercontent.com/wiedehopf/tar1090/master/version")
-    if  [[ "$(cat $gpath/git/version 2>/dev/null)" != "$VERSION_NEW" ]]; then
+    if  [[ "$(cat "$gpath/git/version" 2>/dev/null)" != "$VERSION_NEW" ]]; then
         if ! getGIT "$repo" "master" "$gpath/git"; then
             echo "Unable to download files, exiting! (Maybe try again?)"
             exit 1

--- a/rootfs/tar1090-install.sh
+++ b/rootfs/tar1090-install.sh
@@ -111,7 +111,10 @@ function revision() {
 }
 
 if ! { [[ "$1" == "test" ]] && cd "$gpath/git-db"; }; then
-    getGIT "$db_repo" "master" "$gpath/git-db" || true
+    DB_VERSION_NEW=$(curl --silent --show-error "https://raw.githubusercontent.com/wiedehopf/tar1090-db/master/version")
+    if  [[ "$(cat $gpath/git-db/version 2>/dev/null)" != "$DB_VERSION_NEW" ]]; then
+        getGIT "$db_repo" "master" "$gpath/git-db" || true
+    fi
 fi
 
 if ! cd "$gpath/git-db"
@@ -135,8 +138,14 @@ if [[ "$1" == "test" ]] || [[ -n "$git_source" ]]; then
     cd "$gpath/git"
     TAR_VERSION="$(date +%s)_${RANDOM}${RANDOM}"
 else
-    if ! getGIT "$repo" "master" "$gpath/git" || ! cd "$gpath/git"
-    then
+    VERSION_NEW=$(curl --silent --show-error "https://raw.githubusercontent.com/wiedehopf/tar1090/master/version")
+    if  [[ "$(cat $gpath/git/version 2>/dev/null)" != "$VERSION_NEW" ]]; then
+        if ! getGIT "$repo" "master" "$gpath/git"; then
+            echo "Unable to download files, exiting! (Maybe try again?)"
+            exit 1
+        fi
+    fi
+    if ! cd "$gpath/git"; then
         echo "Unable to download files, exiting! (Maybe try again?)"
         exit 1
     fi
@@ -365,7 +374,6 @@ do
     mv nginx.conf.orig nginx.conf
     mv tar1090.service.orig tar1090.service
 done < <(echo "$instances")
-
 
 if [[ $lighttpd == yes ]] || [[ $nginx == yes ]]; then
     true


### PR DESCRIPTION
Use version files downloaded via curl instead of invoking git to check the version.