### PR TITLE
run nginx when at least 1 server is defined

### DIFF
--- a/rootfs/etc/nginx.tar1090/nginx.conf
+++ b/rootfs/etc/nginx.tar1090/nginx.conf
@@ -1,5 +1,5 @@
 user www-data;
-worker_processes auto;
+worker_processes 1;
 pid /run/nginx.pid;
 include /etc/nginx/modules-enabled/*.conf;
 daemon off;

--- a/rootfs/etc/s6-overlay/scripts/nginx
+++ b/rootfs/etc/s6-overlay/scripts/nginx
@@ -3,7 +3,7 @@
 
 source /scripts/common
 
-if [[ "$(ls /etc/nginx/sites-enabled | wc -l)" == "0" ]]; then
+if [[ "$(find /etc/nginx/sites-enabled/ -type f | wc -l)" == "0" ]]; then
     exec sleep infinity
 fi
 

--- a/rootfs/etc/s6-overlay/scripts/nginx
+++ b/rootfs/etc/s6-overlay/scripts/nginx
@@ -3,9 +3,10 @@
 
 source /scripts/common
 
-if  chk_enabled "${TAR1090_DISABLE}"; then
+if [[ "$(ls /etc/nginx/sites-enabled | wc -l)" == "0" ]]; then
     exec sleep infinity
 fi
+
 
 mkdir -p /var/log/nginx
 

--- a/rootfs/etc/s6-overlay/startup.d/02-tar1090-update
+++ b/rootfs/etc/s6-overlay/startup.d/02-tar1090-update
@@ -3,7 +3,7 @@
 
 source /scripts/common
 
-if ! chk_enabled "${UPDATE_TAR1090}"; then
+if ! chk_enabled "${UPDATE_TAR1090}" || chk_enabled "${TAR1090_DISABLE}"; then
     exit 0
 fi
 

--- a/rootfs/etc/s6-overlay/startup.d/04-tar1090-configure
+++ b/rootfs/etc/s6-overlay/startup.d/04-tar1090-configure
@@ -3,6 +3,13 @@
 
 source /scripts/common
 
+
+if chk_enabled "${TAR1090_DISABLE}"; then
+    rm -f /etc/nginx/sites-enabled/tar1090
+    exit 0
+fi
+
+
 # create symlink so /var/cache/fontconfig is in tmpfs
 # as per Wiedehopf - https://discord.com/channels/734090820684349521/1102603003376177172/1203826726023729162
 # shellcheck disable=SC2174

--- a/rootfs/etc/s6-overlay/startup.d/06-range-outline
+++ b/rootfs/etc/s6-overlay/startup.d/06-range-outline
@@ -3,6 +3,10 @@
 
 source /scripts/common
 
+if chk_enabled "${TAR1090_DISABLE}"; then
+    exit 0
+fi
+
 # https://github.com/wiedehopf/tar1090#heywhatsthatcom-range-outline
 
 if [ -n "${HEYWHATSTHAT_PANORAMA_ID}" ]; then

--- a/rootfs/etc/s6-overlay/startup.d/08-graphs1090-down
+++ b/rootfs/etc/s6-overlay/startup.d/08-graphs1090-down
@@ -1,8 +1,0 @@
-#!/command/with-contenv bash
-# shellcheck shell=bash disable=SC1091
-
-source /scripts/common
-
-if chk_enabled "${GRAPHS1090_DISABLE}"; then
-    exit 0
-fi


### PR DESCRIPTION
to make TAR1090_DISABLE work together with serving prometheus on 9274 using nginx in ultrafeeder

run only 1 nginx worker, more should never be needed