### PR TITLE
URL_AIRSPY: get airspy stats via http

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,8 @@ This container accepts HTTP connections on TCP port `80` by default. You can cha
 | `READSB_DEBUG`             | Optional, used to set debug mode. `n`: network, `P`: CPR, `S`: speed check                                                                                                              | Unset                |
 | `S6_SERVICES_GRACETIME`    | Optional, set to 30000 when saving traces / globe_history                                                                                                                               | `3000`               |
 | `ENABLE_AIRSPY`            | Optional, set to any non-empty value if you want to enable the special AirSpy graphs. See below for additional configuration requirements                                               | Unset                |
+| `URL_AIRSPY`               | Optional, set to the URL where the airspy stats are available, for example `http://airspy_adsb`                                                                                         | Unset                |
+| `URL_1090_SIGNAL`          | Optional. Retrieve gain, % of strong signals and signal graph data from a remote source. Set to an URL where the readsb stats are available, i.e. `http://192.168.2.34/tar1090`         | Unset                |
 
 READSB_EXTRA_ARGS just passes arguments to the commandline, you can check this file for more options for wiedehofps readsb fork: <https://github.com/wiedehopf/readsb/blob/dev/help.h>
 

--- a/rootfs/etc/s6-overlay/startup.d/08-graphs1090-init
+++ b/rootfs/etc/s6-overlay/startup.d/08-graphs1090-init
@@ -50,6 +50,19 @@ else
     sed -i 's/div id="panel_airspy" class="panel panel-default" style="display:block"/div id="panel_airspy" class="panel panel-default" style="display:none"/g' /usr/share/graphs1090/html/index.html
 fi
 
+# allow for changing the data source for various stats graphs1090 collects
+if [[ -n "${URL_AIRSPY}" ]]; then
+    sed -i -e "s|^\s*#*\s*URL_AIRSPY.*|            URL_AIRSPY \"${URL_AIRSPY}\"|g" /etc/collectd/collectd.conf
+fi
+
+if [[ -n "${URL_1090_SIGNAL}" ]]; then
+    sed -i -e "s|^\s*#*\s*URL_1090_SIGNAL.*|            URL_1090_SIGNAL \"${URL_1090_SIGNAL}\"|g" /etc/collectd/collectd.conf
+fi
+
+if [[ -n "${URL_1090}" ]]; then
+    sed -i -e "s|^\s*URL .*|            URL \"${URL_1090}\"|g" /etc/collectd/collectd.conf
+fi
+
 # Enable UAT graphs if URL_978 is set:
 if [[ -n "${URL_978}" ]]; then
     sed -i 's/div id="panel_978" class="panel panel-default" style="display:none"/div id="panel_978" class="panel panel-default" style="display:block"/g' /usr/share/graphs1090/html/index.html


### PR DESCRIPTION
this removes the necessity to mount a common folder to get airspy stats

add some env vars to configure where graph1090 gets the data

URL_1090_SIGNAL is for a remotely running readsb/tar1090 so that this container will show the gain that has been set and the percentage of strong signals