### PR TITLE
graphs1090 reduce io logic fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,10 +30,11 @@ ENV BEASTPORT=30005 \
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# only copy files necessary for the build, copy whole rootfs later
-# this improves build caching when changing service and startup scripting
-COPY rootfs/tar1090-install.sh /
-COPY rootfs/etc/nginx.tar1090 /etc/nginx.tar1090
+#COPY rootfs/tar1090-install.sh /
+#COPY rootfs/etc/nginx.tar1090 /etc/nginx.tar1090
+# for dev testing, rootfs copy can be moved after run, then these two lines above are needed
+
+COPY rootfs/ /
 
 # add telegraf binary
 ##telegraf##COPY --from=telegraf /usr/bin/telegraf /usr/bin/telegraf
@@ -182,8 +183,6 @@ RUN set -x && \
     bash -ec 'echo "$(TZ=UTC date +%Y%m%d-%H%M%S)_$(git rev-parse --short HEAD)_$(git branch --show-current)" > /.CONTAINER_VERSION' && \
     popd && \
     rm -rf /tmp/*
-
-COPY rootfs/ /
 
 EXPOSE 80/tcp
 

--- a/rootfs/etc/s6-overlay/scripts/collectd
+++ b/rootfs/etc/s6-overlay/scripts/collectd
@@ -15,7 +15,10 @@ fi
 PERMFILE=/var/lib/collectd/rrd/localhost.tar.gz
 if chk_enabled "${GRAPHS1090_REDUCE_IO}"; then
     # readback rrd database from compressed archive
-    s6wrap --quiet --prepend=graphs1090-readback --timestamps --args bash /usr/share/graphs1090/readback.sh
+    if ! s6wrap --quiet --prepend=graphs1090-readback --timestamps --args bash /usr/share/graphs1090/readback.sh; then
+        s6wrap --quiet --prepend=graphs1090-readback --timestamps --args echo "FATAL: readback returned an error"
+        exec sleep infinity
+    fi
 elif [[ -f "${PERMFILE}" ]] && ! [[ -d /var/lib/collectd/rrd/localhost ]]; then
     # extract rrd database from compressed archive (in case  WAS enabled)
     if s6wrap --quiet --prepend=graphs1090-extract --timestamps --args bash /usr/share/graphs1090/gunzip.sh /var/lib/collectd/rrd/localhost; then


### PR DESCRIPTION
If the readback fails, the writeback won't happen
Thus make readback fails fatal and not start collectd in this case.

Readback fails should pretty much never happen :/
Like this no graphs will be shown which is likelier to get the users
attention than for example graphs without old data showing.