### PR TITLE
Export the last1min readsb stats to Telegraf

### DIFF
--- a/rootfs/etc/telegraf/telegraf.d/readsb_stats_json.conf
+++ b/rootfs/etc/telegraf/telegraf.d/readsb_stats_json.conf
@@ -11,3 +11,6 @@
       path = "aircraft_without_pos"
     [[inputs.file.json_v2.object]]
       path = "aircraft_count_by_type"
+    [[inputs.file.json_v2.object]]
+      path = "last1min"
+      excluded_keys = ["start", "end", "remote_accepted"]


### PR DESCRIPTION
This brings a bit more parity to stats exposed to Telegraf compared to the stats exposed to Prometheus.