### PR TITLE
Fix: Add IPv6 support to nginx (listen [::]:80)

### DIFF
--- a/rootfs/etc/nginx.tar1090/sites-enabled/tar1090
+++ b/rootfs/etc/nginx.tar1090/sites-enabled/tar1090
@@ -1,5 +1,6 @@
 server {
   listen 80 default_server;
+  listen [::]:80 default_server;
   root /var/www/html;
   server_name _;
   include /etc/nginx/nginx-tar1090-webroot.conf;


### PR DESCRIPTION
Adds `listen [::]:80 default_server;` to the nginx server block to enable 
dual-stack IPv4/IPv6 support.

Without this, clients on dual-stack networks that prefer IPv6 (which is the 
default for most modern OSes) get a connection reset. This also affects anyone 
running behind an IPv6-capable reverse proxy like Traefik or Caddy.

Related issue: sdr-enthusiasts/docker-adsb-ultrafeeder#244