### PR TITLE
ci: fix DL3025

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -149,4 +149,4 @@ COPY rootfs/ /
 EXPOSE 80/tcp
 
 # Add healthcheck
-HEALTHCHECK --start-period=600s --interval=600s CMD /healthcheck.sh
+HEALTHCHECK --start-period=600s --interval=600s CMD ["/healthcheck.sh"]


### PR DESCRIPTION
## Problem

hadolint [#1209](https://github.com/hadolint/hadolint/pull/1209) extended `DL3025` to fire on `HEALTHCHECK ... CMD` as well as `CMD`/`ENTRYPOINT`, shipping in v2.15.0 (published 2026-07-30T13:39:01Z). `DL3025` itself is not new; only the `HEALTHCHECK` coverage is.

```console
$ hadolint --config <shared ruleset> Dockerfile     # 2.14.0, the flake.lock pin
rc=0

$ hadolint --config <shared ruleset> Dockerfile     # 2.15.1
Dockerfile:152 DL3025 warning: Use arguments JSON notation for CMD and ENTRYPOINT arguments
rc=1
```

`check_docker` is already `true` here, so this is a latent `Lint` failure on every PR the moment a `flake.lock` bump lands 2.15.x. There is no hadolint job in the deploy workflow, so the deploy path was never at risk.

## Changes

```diff
-HEALTHCHECK --start-period=600s --interval=600s CMD /healthcheck.sh
+HEALTHCHECK --start-period=600s --interval=600s CMD ["/healthcheck.sh"]
```

## Verification

The exec form drops the intervening `/bin/sh -c`, so the kernel must resolve the script's `#!/command/with-contenv bash` shebang itself — a symlink into the s6-overlay tree, not a normal interpreter path. Preconditions confirmed in the published image, then both forms run side by side under Docker's real healthcheck machinery — the **published image** (shell form) against a **local build of this branch** (exec form), with only the probe timing overridden:

```text
=== published / shell ===              === rebuilt / exec ===
healthy                                healthy
["CMD-SHELL","/healthcheck.sh"]        ["CMD","/healthcheck.sh"]
exit=0                                 exit=0
```

The captured output matches except for the epoch timestamps the script itself prints on each invocation:

```text
readsb last updated: 1785941614.000, now: 1785941614.324147607, delta: .324147607. HEALTHY   <- shell
readsb last updated: 1785941614.000, now: 1785941614.552131039, delta: .552131039. HEALTHY   <- exec
nginx deaths: 0. HEALTHY
readsb deaths: 0. HEALTHY
tar1090 deaths: 0. HEALTHY
file check: /usr/share/graphs1090/data-symlink/data/receiver.json contains data. HEALTHY.
```

Those differ between any two probes regardless of form — the script prints the current time. Every other line is identical.

Because this probe **passes**, the failure direction was checked separately on the same image, since a passing probe alone cannot prove exec form propagates a non-zero exit. A throwaway layer with `HEALTHCHECK CMD ["/bin/false"]`:

```text
exec-form non-zero -> status=unhealthy  exit=1
```

Image config compared against the published image — only `Test[0]` differs:

```console
built    : {"Test":["CMD","/healthcheck.sh"],"Interval":600000000000,"StartPeriod":600000000000}
published: {"Test":["CMD-SHELL","/healthcheck.sh"],"Interval":600000000000,"StartPeriod":600000000000}
```

`Config.Entrypoint` is `["/init"]` on both, so s6 remains PID 1 and `docker stop` still reaches it for graceful shutdown.

Also checked:

- `nix develop -c pre-commit run --all-files`: green, all hooks Passed or Skipped
- `docker build --platform linux/amd64`: succeeds
- No hooks bypassed; no `--no-verify`
